### PR TITLE
fix 1-polymer-first-app

### DIFF
--- a/static/codelabs/ja/1-polymer-first-app/5-finishing-touches.md
+++ b/static/codelabs/ja/1-polymer-first-app/5-finishing-touches.md
@@ -148,7 +148,7 @@ paper-icon-button {
   <post-card
     favorite="{{post.favorite}}"
     on-favorite-tap="handleFavorite"
-    hidden$="{{isHidden(show, post)}}">
+    hidden$="{{isHidden(show, post.favorite)}}">
   <!-- ここまで -->
     <img src="{{post.avatar}}" width="70" height="70">
     <h2>{{post.username}}</h2>
@@ -192,8 +192,8 @@ paper-icon-button {
         reflectToAttribute: true
       }
     },
-    isHidden: function(show, post) {
-      return show === 'favorites' && !post.favorite;
+    isHidden: function(show, favorite) {
+      return show === 'favorites' && !favorite;
     },
     handleFavorite: function(event) {
       var post = event.model.post;

--- a/static/codelabs/ja/1-polymer-first-app/PolymerApp/step-5/post-list.html
+++ b/static/codelabs/ja/1-polymer-first-app/PolymerApp/step-5/post-list.html
@@ -29,7 +29,7 @@
         <post-card
           favorite="{{post.favorite}}"
           on-favorite-tap="handleFavorite"
-          hidden$="{{isHidden(show, post)}}">
+          hidden$="{{isHidden(show, post.favorite)}}">
           <img src="{{post.avatar}}" width="70" height="70">
           <h2>{{post.username}}</h2>
           <p>{{post.text}}</p>
@@ -50,8 +50,8 @@
         reflectToAttribute: true
       }
     },
-    isHidden: function(show, post) {
-      return show === 'favorites' && !post.favorite;
+    isHidden: function(show, favorite) {
+      return show === 'favorites' && !favorite;
     },
     handleFavorite: function(event) {
       var post = event.model.post;


### PR DESCRIPTION
Polymerコードラボの日本語 1.0 版のサンプルコードの 1-polymer-first-app を動かしていて、
以下の操作をした際に期待通りに動きません。
1. Messages Tab でいずれかの post の favorite を ON にする
2. Messages Tab -> Favorites Tab に切り替える ( post.favorite ON がリストに表示される )
3. Favorites Tab でいずれかの post の favorite を OFF にする ( post.favorite OFF だがリストに表示されたまま )

原因としては post.favorite プロパティの変更時に `{{isHidden(show, post)}}` という computed binding が動かないからです。

対応としては依存関係のあるプロパティに `post.favorite` を含めるために `{{isHidden(show, post.favorite)}}` とします。

参考にしたドキュメントは次のものです。 https://www.polymer-project.org/1.0/docs/devguide/data-binding.html#dependent-properties

---

そもそも、ここに Pull Request するのが正解なのかはわかりませんが、サンプルコードのリンク先がこちらだったので、こちらに投げています。
